### PR TITLE
Fix error when item window doesn't have id link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,10 +80,9 @@ const originalDocumentIdLink = (DocumentSheet.prototype as any)._createDocumentI
     }
 
     const ret: any = originalDocumentIdLink.call(this, html);
-    const idLink = html.find('.document-id-link');
+    let node: Node | undefined = html.find('.document-id-link').get(0);
 
-    if (idLink) {
-        let node: Node = idLink.get(0)!;
+    if (node) {
         const overrideCopyId: boolean = getSetting(Setting.OVERRIDE_COPY_ID);
         if (overrideCopyId) {
             const newNode: Node = node.cloneNode(true);


### PR DESCRIPTION
I found there are some cases when window doesn't have `document-id-link` and it will result error, that will block such windows from opening

current check 

```js
    const idLink = html.find('.document-id-link');

    if (idLink) {
```

is slightly incorrect, because jQuery `find` will always return jQuery object
so we need to check existence of DOM node instead